### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var resource = require('resource'),
     crypto = require('crypto'),
-    uuid = require('node-uuid');
+    uuid = require('uuid');
 
 var user = resource.define('user', { 
   controller: require('./lib/'), 

--- a/lib/reset.js
+++ b/lib/reset.js
@@ -1,4 +1,4 @@
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 module['exports'] = function (options, callback) {
   var user = require('../');

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.6.1",
   "description": "resource for managing users",
   "repository": {
-   "type": "git",
-   "url": "http://github.com/bigcompany/user.git"
+    "type": "git",
+    "url": "http://github.com/bigcompany/user.git"
   },
   "keywords": [
     "user",
@@ -15,7 +15,7 @@
   "main": "./index.js",
   "dependencies": {
     "resource": "0.6.x",
-    "node-uuid": "1.4.x"
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "tap": "0.4.x"


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.